### PR TITLE
fix: query for stylesheet `<link>`s explicitly

### DIFF
--- a/switcher.js
+++ b/switcher.js
@@ -36,14 +36,13 @@ function inline_switcher() {
 }
 
 function add_switcher() {
-  css_link = document.getElementsByTagName("link")[0];
+  css_link = document.querySelectorAll("link[rel='stylesheet']")[0];
   if (css_link == undefined) {
-    head = document.getElementsByTagName('head')[0];
     css_link = document.createElement('link');
     css_link.rel="stylesheet";
     css_link.type="text/css";
     css_link.href="https://dohliam.github.io/dropin-minimal-css/min/" + frameworks.split(",")[0] + ".min.css";
-    head.appendChild(css_link);
+    document.head.appendChild(css_link);
   }
 
   var new_div = document.createElement('div');


### PR DESCRIPTION
I was trying out the bookmarklet and was finding some sites it wasn't working on where the first `<link>` tag in the `<head>` wasn't always a `<link rel="stylesheet">` but rather [something else](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) and so it wasn't actually working.

I updated the code to specifically check for a `link[rel=stylesheet]` which should be a bit more robust.